### PR TITLE
fix: check has mentor and align card-trail

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6616,7 +6616,7 @@ const TitleMentoring = styled__default["default"].span `
 const TextDescription = styled__default["default"](_.Typography) `
   margin-top: 10px !important;
   white-space: normal !important;
-  height: 90px !important;
+  height: 102px !important;
   overflow: hidden !important;
   display: -webkit-box;
   -webkit-line-clamp: 6; 
@@ -6669,7 +6669,7 @@ const MyCardContent = styled__default["default"](_.CardContent) `
     height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: ${({ hasMentor }) => hasMentor ? 'space-between' : 'flex-start'};
 `;
 const WrapperDate = styled__default["default"].div `
     display: ${({ notStarted }) => notStarted ? 'flex' : 'none'};
@@ -6684,7 +6684,7 @@ function CardTrail(props) {
         return window.open(URL);
     };
     return (jsxRuntime.jsx(styled.ThemeProvider, { theme: FRSTTheme, children: jsxRuntime.jsxs(CardContainer, { children: [!props?.notStarted && props.variant == 'primary' &&
-                    jsxRuntime.jsx(PercentageProgress, { progress: props.progress }), jsxRuntime.jsx(HeaderImage, { onClick: redirectToD2L, image: props.bannerImage, notStarted: props?.notStarted }), jsxRuntime.jsx(MyBox, { children: jsxRuntime.jsxs(MyCardContent, { notStarted: props?.notStarted, children: [jsxRuntime.jsx(TitleCard, { onClick: redirectToD2L, children: props.name }), jsxRuntime.jsx(TextDescription, { onClick: redirectToD2L, children: props.description }), props.variant == 'primary' ?
+                    jsxRuntime.jsx(PercentageProgress, { progress: props.progress }), jsxRuntime.jsx(HeaderImage, { onClick: redirectToD2L, image: props.bannerImage, notStarted: props?.notStarted }), jsxRuntime.jsx(MyBox, { children: jsxRuntime.jsxs(MyCardContent, { notStarted: props?.notStarted, hasMentor: props.mentor?.name, children: [jsxRuntime.jsx(TitleCard, { onClick: redirectToD2L, children: props.name }), jsxRuntime.jsx(TextDescription, { onClick: redirectToD2L, children: props.description }), props.variant == 'primary' ?
                                 jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [jsxRuntime.jsxs(WrapperDate, { onClick: redirectToD2L, notStarted: props?.notStarted, children: [jsxRuntime.jsxs("b", { children: [props.labels?.dateStart ? props.labels?.dateStart : 'Data de início', ":\u00A0"] }), props.start] }), props.mentor?.name &&
                                             jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [jsxRuntime.jsx(TitleMentoring, { onClick: redirectToD2L, children: props.labels?.mentor ? props.labels?.mentor : 'Mentor(a)' }), jsxRuntime.jsx(MentorComponent, { mentor: props.mentor, notStarted: props?.notStarted })] })] })
                                 :

--- a/dist/src/components/card-trail/cardTrailStyle.d.ts
+++ b/dist/src/components/card-trail/cardTrailStyle.d.ts
@@ -5,6 +5,7 @@ export declare const HeaderImage: import("styled-components").StyledComponent<im
 export declare const MyBox: import("styled-components").StyledComponent<import("@mui/material/OverridableComponent").OverridableComponent<import("@mui/material/").BoxTypeMap<{}, "div">>, any, {}, never>;
 export declare const MyCardContent: import("styled-components").StyledComponent<import("@mui/material/OverridableComponent").OverridableComponent<import("@mui/material/").CardContentTypeMap<{}, "div">>, any, {
     notStarted: any;
+    hasMentor: any;
 }, never>;
 export declare const WrapperDate: import("styled-components").StyledComponent<"div", any, {
     notStarted: any;

--- a/dist/src/components/card-trail/cardTrailStyle.d.ts.map
+++ b/dist/src/components/card-trail/cardTrailStyle.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"cardTrailStyle.d.ts","sourceRoot":"","sources":["../../../../src/components/card-trail/cardTrailStyle.ts"],"names":[],"mappings":"AAIA,eAAO,MAAM,WAAW;;;SAOvB,CAAA;AAED,eAAO,MAAM,KAAK,gLAIjB,CAAA;AAED,eAAO,MAAM,aAAa;;SAMzB,CAAA;AAED,eAAO,MAAM,WAAW;;SAGvB,CAAA"}
+{"version":3,"file":"cardTrailStyle.d.ts","sourceRoot":"","sources":["../../../../src/components/card-trail/cardTrailStyle.ts"],"names":[],"mappings":"AAIA,eAAO,MAAM,WAAW;;;SAOvB,CAAA;AAED,eAAO,MAAM,KAAK,gLAIjB,CAAA;AAED,eAAO,MAAM,aAAa;;;SAMzB,CAAA;AAED,eAAO,MAAM,WAAW;;SAGvB,CAAA"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frst-components",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "frst-components",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "dependencies": {
         "@emoji-mart/data": "^1.0.2",
         "@emotion/css": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frst-components",
   "homepage": "http://FRST-Falconi.github.io/storybook.frstfalconi.com",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/components/card-trail/cardTrailStyle.ts
+++ b/src/components/card-trail/cardTrailStyle.ts
@@ -17,12 +17,12 @@ export const MyBox = styled(Box)`
     padding-top: 12px;
 `
 
-export const MyCardContent = styled(CardContent)<{notStarted}>`
+export const MyCardContent = styled(CardContent)<{notStarted, hasMentor}>`
     cursor: ${({notStarted}) => notStarted ? 'no-drop' : 'pointer'};
     height: 100%;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    justify-content: ${({hasMentor}) => hasMentor ? 'space-between' : 'flex-start'};
 `
 
 export const WrapperDate = styled.div<{notStarted}>`

--- a/src/components/card-trail/index.tsx
+++ b/src/components/card-trail/index.tsx
@@ -58,7 +58,7 @@ export default function CardTrail(props: ModuleCardProps) {
         />
 
         <MyBox>
-          <MyCardContent notStarted={props?.notStarted} >
+          <MyCardContent notStarted={props?.notStarted} hasMentor={props.mentor?.name} >
             <Styles.TitleCard onClick={redirectToD2L} >{props.name}</Styles.TitleCard>
             <Styles.TextDescription onClick={redirectToD2L} >
               {props.description}

--- a/src/components/card-trail/moduleStyle.ts
+++ b/src/components/card-trail/moduleStyle.ts
@@ -60,7 +60,7 @@ export const TitleMentoring = styled.span`
 export const TextDescription = styled(Typography)`
   margin-top: 10px !important;
   white-space: normal !important;
-  height: 90px !important;
+  height: 102px !important;
   overflow: hidden !important;
   display: -webkit-box;
   -webkit-line-clamp: 6; 


### PR DESCRIPTION
Corrigindo alinhamento informações quando não há informação de mentor em componente Card Trail.

![image](https://user-images.githubusercontent.com/14964654/197829524-069c871f-82b3-48d8-92e6-8cd0e7780e69.png)
