### PR TITLE
:boom: fix: substituído logo desfocado no component postFeed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frst-components",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frst-components",
-      "version": "0.13.2",
+      "version": "0.13.3",
       "dependencies": {
         "@emoji-mart/data": "^1.0.2",
         "@emotion/css": "^11.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frst-components",
   "homepage": "http://FRST-Falconi.github.io/storybook.frstfalconi.com",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "private": true,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/components/FI/postFeed/index.tsx
+++ b/src/components/FI/postFeed/index.tsx
@@ -51,7 +51,7 @@ interface IPostFeed{
 }
 
 export default function PostFeed( props : IPostFeed ){
-    const FRSTAvatar = 'https://i.gyazo.com/e9608cb76d36242de07661bee9da60dd.png'
+    const FRSTAvatar = 'https://api-deimos-cdn.frstfalconi.cloud/logo_first.png'
 
     const [isVisibleComments, setIsVisibleComments] = useState(props.isVisibleComments)
     const [ actionArea, setActionArea] = useState(false)


### PR DESCRIPTION
## Description

:boom: fix: substituído logo desfocado no component postFeed
- [#864e3nj40](https://app.clickup.com/t/864e3nj40)


## Related Issue
 - N/A
 
## How Has This Been Tested?

![Captura de tela de 2023-04-06 11-42-58](https://user-images.githubusercontent.com/94614482/230416087-3549bd53-e5ac-4064-802e-056a17b51d6c.png)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


